### PR TITLE
Normalize class token for engine startup

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -128,13 +128,16 @@ end
 function TR:HandleWorldEnter()
   local _, class = UnitClass("player")
   if not class then return end
-  
+
+  -- normalize the class token to proper case (e.g., "WARRIOR" -> "Warrior")
+  local camel = class:lower():gsub('^%l', string.upper)
+
   self._engineStates = self._engineStates or {}
-  
-  local startMethod = "StartEngine_" .. class
-  if self[startMethod] and not self._engineStates[class] then
+
+  local startMethod = "StartEngine_" .. camel
+  if self[startMethod] and not self._engineStates[camel] then
     self[startMethod](self)
-    self._engineStates[class] = true
+    self._engineStates[camel] = true
   end
   
   if self.SendMessage then 


### PR DESCRIPTION
## Summary
- Normalize player class token to proper case before starting engine
- Track engine start state using normalized class key

## Testing
- `luac -p core.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af54a99c83309b58f50c3e895cef