### PR TITLE
fix: correct SweepingStrikes ability key

### DIFF
--- a/warrior_ids.lua
+++ b/warrior_ids.lua
@@ -9,7 +9,7 @@ local IDS = {
     MortalStrike     = 12294,
     Rend             = 772,
     Overpower        = 7384,
-    Sweeping Strikes = 12328,
+    SweepingStrikes  = 12328,
     
     -- Fury  
     Bloodthirst      = 23881,


### PR DESCRIPTION
## Summary
- ensure SweepingStrikes ability key matches rank table

## Testing
- `luac -p warrior_ids.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4af4bcd3c833094a9c8e4a4aee45a