### PR TITLE
Add basic engines and IDs for all classes

### DIFF
--- a/classes/Engines/druid_engine.lua
+++ b/classes/Engines/druid_engine.lua
@@ -1,0 +1,80 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Druid
+
+local TOKEN = "DRUID"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target",3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if not InMelee() and main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Druid()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Druid()
+  self:StopEngine_Druid()
+  self:EngineTick_Druid()
+  self._engineTimer_DR = self:ScheduleRepeatingTimer("EngineTick_Druid", 0.2)
+  self:Print("TacoRot Druid engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Druid()
+  if self._engineTimer_DR then
+    self:CancelTimer(self._engineTimer_DR)
+    self._engineTimer_DR = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "DRUID" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Druid then
+      TR:StartEngine_Druid()
+    end
+  end)
+end

--- a/classes/Engines/mage_engine.lua
+++ b/classes/Engines/mage_engine.lua
@@ -1,0 +1,83 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Mage
+
+local TOKEN = "MAGE"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target", 3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.Wand or IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 and IDS.Ability.Wand and not InMelee() then
+    Push(q, IDS.Ability.Wand)
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Mage()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Mage()
+  self:StopEngine_Mage()
+  self:EngineTick_Mage()
+  self._engineTimer_MA = self:ScheduleRepeatingTimer("EngineTick_Mage", 0.2)
+  self:Print("TacoRot Mage engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Mage()
+  if self._engineTimer_MA then
+    self:CancelTimer(self._engineTimer_MA)
+    self._engineTimer_MA = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "MAGE" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Mage then
+      TR:StartEngine_Mage()
+    end
+  end)
+end

--- a/classes/Engines/paladin_engine.lua
+++ b/classes/Engines/paladin_engine.lua
@@ -1,0 +1,80 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Paladin
+
+local TOKEN = "PALADIN"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target",3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Paladin()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Paladin()
+  self:StopEngine_Paladin()
+  self:EngineTick_Paladin()
+  self._engineTimer_PA = self:ScheduleRepeatingTimer("EngineTick_Paladin", 0.2)
+  self:Print("TacoRot Paladin engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Paladin()
+  if self._engineTimer_PA then
+    self:CancelTimer(self._engineTimer_PA)
+    self._engineTimer_PA = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "PALADIN" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Paladin then
+      TR:StartEngine_Paladin()
+    end
+  end)
+end

--- a/classes/Engines/priest_engine.lua
+++ b/classes/Engines/priest_engine.lua
@@ -1,0 +1,83 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Priest
+
+local TOKEN = "PRIEST"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target",3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.Wand or IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 and IDS.Ability.Wand and not InMelee() then
+    Push(q, IDS.Ability.Wand)
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Priest()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Priest()
+  self:StopEngine_Priest()
+  self:EngineTick_Priest()
+  self._engineTimer_PR = self:ScheduleRepeatingTimer("EngineTick_Priest", 0.2)
+  self:Print("TacoRot Priest engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Priest()
+  if self._engineTimer_PR then
+    self:CancelTimer(self._engineTimer_PR)
+    self._engineTimer_PR = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "PRIEST" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Priest then
+      TR:StartEngine_Priest()
+    end
+  end)
+end

--- a/classes/Engines/rogue_engine.lua
+++ b/classes/Engines/rogue_engine.lua
@@ -1,0 +1,80 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Rogue
+
+local TOKEN = "ROGUE"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target",3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if InMelee() and main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Rogue()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Rogue()
+  self:StopEngine_Rogue()
+  self:EngineTick_Rogue()
+  self._engineTimer_RO = self:ScheduleRepeatingTimer("EngineTick_Rogue", 0.2)
+  self:Print("TacoRot Rogue engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Rogue()
+  if self._engineTimer_RO then
+    self:CancelTimer(self._engineTimer_RO)
+    self._engineTimer_RO = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "ROGUE" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Rogue then
+      TR:StartEngine_Rogue()
+    end
+  end)
+end

--- a/classes/Engines/shaman_engine.lua
+++ b/classes/Engines/shaman_engine.lua
@@ -1,0 +1,80 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Shaman
+
+local TOKEN = "SHAMAN"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target",3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Shaman()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Shaman()
+  self:StopEngine_Shaman()
+  self:EngineTick_Shaman()
+  self._engineTimer_SH = self:ScheduleRepeatingTimer("EngineTick_Shaman", 0.2)
+  self:Print("TacoRot Shaman engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Shaman()
+  if self._engineTimer_SH then
+    self:CancelTimer(self._engineTimer_SH)
+    self._engineTimer_SH = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "SHAMAN" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Shaman then
+      TR:StartEngine_Shaman()
+    end
+  end)
+end

--- a/classes/Engines/warlock_engine.lua
+++ b/classes/Engines/warlock_engine.lua
@@ -1,0 +1,83 @@
+local TR = _G.TacoRot
+if not TR then return end
+local IDS = _G.TacoRot_IDS_Warlock
+
+local TOKEN = "WARLOCK"
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled=true, gcd=1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id) return id and IsSpellKnown and IsSpellKnown(id) end
+local function ReadyNow(id)
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  return (GetTime() - start) >= duration
+end
+local function ReadySoon(id)
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
+  local start, duration = GetSpellCooldown(id)
+  if not start or duration == 0 then return true end
+  local remaining = (start + duration) - GetTime()
+  return remaining <= (pad.gcd or 1.5)
+end
+local function HaveTarget()
+  return UnitExists("target") and not UnitIsDead("target") and UnitCanAttack("player", "target")
+end
+local function InMelee() return CheckInteractDistance("target", 3) end
+local function pad3(q, fb) q[1]=q[1] or fb; q[2]=q[2] or q[1]; q[3]=q[3] or q[2]; return q end
+local function Push(q, id) if id then q[#q+1]=id end end
+
+local function BuildQueue()
+  local q = {}
+  if not HaveTarget() then return pad3(q, IDS.Ability.Wand or IDS.Ability.AutoAttack) end
+  local main = IDS.Ability.Main
+  if main and ReadySoon(main) then
+    local usable = IsUsableSpell and select(1, IsUsableSpell(main))
+    if usable then Push(q, main) end
+  end
+  if #q == 0 and IDS.Ability.Wand and not InMelee() then
+    Push(q, IDS.Ability.Wand)
+  end
+  if #q == 0 then Push(q, IDS.Ability.AutoAttack) end
+  return pad3(q, IDS.Ability.AutoAttack)
+end
+
+function TR:EngineTick_Warlock()
+  if IDS and IDS.UpdateRanks then IDS:UpdateRanks() end
+  local q = BuildQueue()
+  self._lastMainSpell = q[1]
+  if self.UI and self.UI.Update then self.UI:Update(q[1], q[2], q[3]) end
+end
+
+function TR:StartEngine_Warlock()
+  self:StopEngine_Warlock()
+  self:EngineTick_Warlock()
+  self._engineTimer_WL = self:ScheduleRepeatingTimer("EngineTick_Warlock", 0.2)
+  self:Print("TacoRot Warlock engine active (Classic Anniversary)")
+end
+
+function TR:StopEngine_Warlock()
+  if self._engineTimer_WL then
+    self:CancelTimer(self._engineTimer_WL)
+    self._engineTimer_WL = nil
+  end
+end
+
+local _, class = UnitClass("player")
+if class == "WARLOCK" then
+  local f = CreateFrame("Frame")
+  f:RegisterEvent("PLAYER_LOGIN")
+  f:SetScript("OnEvent", function()
+    if TR and TR.StartEngine_Warlock then
+      TR:StartEngine_Warlock()
+    end
+  end)
+end

--- a/classes/IDs/druid_ids.lua
+++ b/classes/IDs/druid_ids.lua
@@ -1,0 +1,42 @@
+-- druid_ids.lua — Classic Anniversary Druid IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Druid IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 5176,  -- Wrath
+    Buff       = 774,   -- Rejuvenation
+    AutoAttack = 6603,
+  },
+  Rank = {
+    Main = {5176, 5177, 5178},
+    Buff = {774, 1058, 1430},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Druid = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(5176, "Interface\\Icons\\Spell_Nature_StarFall")
+setOnce(774,  "Interface\\Icons\\Spell_Nature_Rejuvenation")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/mage_ids.lua
+++ b/classes/IDs/mage_ids.lua
@@ -1,0 +1,45 @@
+-- mage_ids.lua — Classic Anniversary Mage IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Mage IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 116,   -- Frostbolt
+    Buff       = 1459,  -- Arcane Intellect
+    AutoAttack = 6603,
+    Wand       = 5019,  -- Shoot
+  },
+  Rank = {
+    Main = {116, 205, 837, 7322},
+    Buff = {1459, 1460, 1461},
+    Wand = {5019},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Mage = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(116,  "Interface\\Icons\\Spell_Frost_FrostBolt02")
+setOnce(1459, "Interface\\Icons\\Spell_Holy_MagicalSentry")
+setOnce(5019, "Interface\\Icons\\INV_Wand_01")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/paladin_ids.lua
+++ b/classes/IDs/paladin_ids.lua
@@ -1,0 +1,42 @@
+-- paladin_ids.lua — Classic Anniversary Paladin IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Paladin IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 20271, -- Judgement
+    Buff       = 19740, -- Blessing of Might
+    AutoAttack = 6603,
+  },
+  Rank = {
+    Main = {20271},
+    Buff = {19740, 19834},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Paladin = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(20271, "Interface\\Icons\\Spell_Holy_RighteousFury")
+setOnce(19740, "Interface\\Icons\\Spell_Holy_FistOfJustice")
+setOnce(6603,  "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/priest_ids.lua
+++ b/classes/IDs/priest_ids.lua
@@ -1,0 +1,45 @@
+-- priest_ids.lua — Classic Anniversary Priest IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Priest IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 585,   -- Smite
+    Buff       = 1243,  -- Power Word: Fortitude
+    AutoAttack = 6603,
+    Wand       = 5019,
+  },
+  Rank = {
+    Main = {585, 591, 598, 984},
+    Buff = {1243, 1244, 1245},
+    Wand = {5019},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Priest = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(585,  "Interface\\Icons\\Spell_Holy_HolyBolt")
+setOnce(1243, "Interface\\Icons\\Spell_Holy_WordFortitude")
+setOnce(5019, "Interface\\Icons\\INV_Wand_01")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/rogue_ids.lua
+++ b/classes/IDs/rogue_ids.lua
@@ -1,0 +1,42 @@
+-- rogue_ids.lua — Classic Anniversary Rogue IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Rogue IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 1752,  -- Sinister Strike
+    Buff       = 5171,  -- Slice and Dice
+    AutoAttack = 6603,
+  },
+  Rank = {
+    Main = {1752, 1757, 1758},
+    Buff = {5171},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Rogue = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(1752, "Interface\\Icons\\Spell_Shadow_RitualOfSacrifice")
+setOnce(5171, "Interface\\Icons\\Ability_Rogue_SliceDice")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/shaman_ids.lua
+++ b/classes/IDs/shaman_ids.lua
@@ -1,0 +1,42 @@
+-- shaman_ids.lua — Classic Anniversary Shaman IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Shaman IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 403,   -- Lightning Bolt
+    Buff       = 324,   -- Lightning Shield
+    AutoAttack = 6603,
+  },
+  Rank = {
+    Main = {403, 529, 548, 915},
+    Buff = {324, 325, 905},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Shaman = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(403,  "Interface\\Icons\\Spell_Nature_Lightning")
+setOnce(324,  "Interface\\Icons\\Spell_Nature_LightningShield")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/classes/IDs/warlock_ids.lua
+++ b/classes/IDs/warlock_ids.lua
@@ -1,0 +1,45 @@
+-- warlock_ids.lua — Classic Anniversary Warlock IDs
+DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Warlock IDS loaded")
+
+local IDS = {
+  Ability = {
+    Main       = 686,   -- Shadow Bolt
+    Buff       = 687,   -- Demon Skin
+    AutoAttack = 6603,
+    Wand       = 5019,
+  },
+  Rank = {
+    Main = {686, 695, 705, 1088},
+    Buff = {687, 696},
+    Wand = {5019},
+    AutoAttack = {6603},
+  },
+}
+
+local function bestRank(list)
+  if not list then return nil end
+  for i = #list, 1, -1 do
+    local id = list[i]
+    if IsSpellKnown and IsSpellKnown(id) then
+      return id
+    end
+  end
+  return list[#list] or list[1]
+end
+
+function IDS:UpdateRanks()
+  for key, list in pairs(self.Rank) do
+    local id = bestRank(list)
+    if id then self.Ability[key] = id end
+  end
+end
+
+_G.TacoRot_IDS_Warlock = IDS
+
+_G.TacoRotIconFallbacks = _G.TacoRotIconFallbacks or {}
+local fb = _G.TacoRotIconFallbacks
+local function setOnce(id, tex) if id and not fb[id] then fb[id] = tex end end
+setOnce(686,  "Interface\\Icons\\Spell_Shadow_ShadowBolt")
+setOnce(687,  "Interface\\Icons\\Spell_Shadow_RagingScream")
+setOnce(5019, "Interface\\Icons\\INV_Wand_01")
+setOnce(6603, "Interface\\Icons\\Ability_MeleeDamage")

--- a/engine_bootstrap.lua
+++ b/engine_bootstrap.lua
@@ -1,0 +1,1 @@
+-- engine_bootstrap.lua placeholder to satisfy toc reference


### PR DESCRIPTION
## Summary
- add skeleton engines for Mage, Warlock, Priest, Shaman, Paladin, Rogue and Druid
- provide matching spell ID tables with auto-attack and wand fallbacks
- include placeholder engine bootstrap file for toc

## Testing
- `busted -v` *(fails: command not found)*
- `lua tests/core_spec.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4bd12c6688330b584c1c595cd3cd3