### PR TITLE
test: expand world enter coverage

### DIFF
--- a/tests/core_spec.lua
+++ b/tests/core_spec.lua
@@ -32,23 +32,64 @@ describe("HandleWorldEnter", function()
     TR = nil
   end)
 
-  it("starts warrior engine on world enter", function()
+  local classes = {
+    Warrior = "WARRIOR",
+    Hunter  = "HUNTER",
+    Warlock = "WARLOCK",
+    Rogue   = "ROGUE",
+    Druid   = "DRUID",
+    Mage    = "MAGE",
+    Paladin = "PALADIN",
+    Priest  = "PRIEST",
+    Shaman  = "SHAMAN",
+  }
+
+  for camel, token in pairs(classes) do
+    it("starts " .. camel .. " engine on world enter", function()
+      _G.UnitClass = function() return nil, token end
+      local called = 0
+      TR["StartEngine_" .. camel] = function()
+        called = called + 1
+      end
+      TR:HandleWorldEnter()
+      assert.are.equal(1, called)
+      assert.is_true(TR._engineStates[camel])
+    end)
+  end
+
+  it("unregisters world enter event", function()
     _G.UnitClass = function() return nil, "WARRIOR" end
-    local called = 0
-    function TR:StartEngine_Warrior()
-      called = called + 1
-    end
+    TR.StartEngine_Warrior = function() end
+    local unregistered
+    TR.UnregisterEvent = function(_, evt) unregistered = evt end
     TR:HandleWorldEnter()
-    assert.are.equal(1, called)
+    assert.are.equal("PLAYER_ENTERING_WORLD", unregistered)
   end)
 
-  it("starts hunter engine on world enter", function()
-    _G.UnitClass = function() return nil, "HUNTER" end
-    local called = 0
-    function TR:StartEngine_Hunter()
-      called = called + 1
-    end
+  it("sends enable class module message", function()
+    _G.UnitClass = function() return nil, "WARRIOR" end
+    TR.StartEngine_Warrior = function() end
+    local msg
+    TR.SendMessage = function(_, m) msg = m end
     TR:HandleWorldEnter()
-    assert.are.equal(1, called)
+    assert.are.equal("TACOROT_ENABLE_CLASS_MODULE", msg)
+  end)
+
+  it("does nothing when class unavailable", function()
+    _G.UnitClass = function() return nil, nil end
+    local called = false
+    TR.StartEngine_Warrior = function() called = true end
+    TR.UnregisterEvent = function() called = true end
+    TR:HandleWorldEnter()
+    assert.is_false(called)
+  end)
+
+  it("does not start engine twice", function()
+    _G.UnitClass = function() return nil, "WARRIOR" end
+    local count = 0
+    TR.StartEngine_Warrior = function() count = count + 1 end
+    TR:HandleWorldEnter()
+    TR:HandleWorldEnter()
+    assert.are.equal(1, count)
   end)
 end)


### PR DESCRIPTION
## Summary
- expand HandleWorldEnter specs to cover all class engines
- verify event unregistration and enable message
- ensure no double-engine start when world enter called again

## Testing
- `busted tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c9217bd88330ba1609a225bf287c