### PR TITLE
Avoid suggesting unknown or active buffs/pet actions

### DIFF
--- a/classes/Engines/hunter_engine.lua
+++ b/classes/Engines/hunter_engine.lua
@@ -4,6 +4,21 @@ DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Hunter engine loaded")
 local TR = _G.TacoRot
 local IDS = _G.TacoRot_IDS_Hunter
 
+local TOKEN = "HUNTER"
+
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled = true, gcd = 1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id)
+  return id and IsSpellKnown and IsSpellKnown(id)
+end
+
 -- Helper functions
 local function BuffCfg()
   return (TR.db and TR.db.profile and TR.db.profile.buff and TR.db.profile.buff.HUNTER) or {}
@@ -59,15 +74,17 @@ local function DebuffUp(unit, spellID)
 end
 
 local function ReadyNow(id)
-  if not id then return false end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
   return start == 0 or (start + dur - GetTime()) < 0.1
 end
 
 local function ReadySoon(id)
-  if not id then return false end
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
-  return start == 0 or (start + dur - GetTime()) < 1.5
+  return start == 0 or (start + dur - GetTime()) < (pad.gcd or 1.5)
 end
 
 local function HaveTarget()

--- a/classes/Engines/mage_engine.lua
+++ b/classes/Engines/mage_engine.lua
@@ -4,6 +4,21 @@ DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Mage engine loaded")
 local TR = _G.TacoRot
 local IDS = _G.TacoRot_IDS_Mage
 
+local TOKEN = "MAGE"
+
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled = true, gcd = 1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id)
+  return id and IsSpellKnown and IsSpellKnown(id)
+end
+
 -- Helper functions
 local function Mana()
   local mana = UnitMana("player")
@@ -40,15 +55,17 @@ local function DebuffUp(unit, spellID)
 end
 
 local function ReadyNow(id)
-  if not id then return false end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
   return start == 0 or (start + dur - GetTime()) < 0.1
 end
 
 local function ReadySoon(id)
-  if not id then return false end
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
-  return start == 0 or (start + dur - GetTime()) < 1.5
+  return start == 0 or (start + dur - GetTime()) < (pad.gcd or 1.5)
 end
 
 local function HaveTarget()

--- a/classes/Engines/rogue_engine.lua
+++ b/classes/Engines/rogue_engine.lua
@@ -4,6 +4,21 @@ DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Rogue engine loaded")
 local TR = _G.TacoRot
 local IDS = _G.TacoRot_IDS_Rogue
 
+local TOKEN = "ROGUE"
+
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled = true, gcd = 1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id)
+  return id and IsSpellKnown and IsSpellKnown(id)
+end
+
 -- Helper functions
 local function GetComboPoints()
   return GetComboPoints("player", "target") or 0
@@ -42,15 +57,17 @@ local function DebuffUp(unit, spellID)
 end
 
 local function ReadyNow(id)
-  if not id then return false end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
   return start == 0 or (start + dur - GetTime()) < 0.1
 end
 
 local function ReadySoon(id)
-  if not id then return false end
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
-  return start == 0 or (start + dur - GetTime()) < 1.5
+  return start == 0 or (start + dur - GetTime()) < (pad.gcd or 1.5)
 end
 
 local function HaveTarget()

--- a/classes/Engines/warlock_engine.lua
+++ b/classes/Engines/warlock_engine.lua
@@ -164,31 +164,40 @@ end
 -- Pet management
 local function BuildPetQueue()
   local q = {}
-  
+
   if not HavePet() then
-    -- Summon pet based on spec/situation
+    local level = UnitLevel("player")
     local spec = GetPrimarySpec()
-    
-    if spec == "Affliction" then
-      -- Felhunter for pvp/dispel utility, or imp for leveling
-      if Known(IDS.Ability.SummonFelhunter) and UnitLevel("player") >= 30 then
-        Push(q, IDS.Ability.SummonFelhunter)
-      else
-        Push(q, IDS.Ability.SummonImp)
-      end
-    elseif spec == "Destruction" then
-      -- Imp for damage boost
-      Push(q, IDS.Ability.SummonImp)
-    else -- Demonology
-      -- Succubus for damage, Voidwalker for tanking
-      if UnitLevel("player") >= 20 then
-        Push(q, IDS.Ability.SummonSuccubus)
-      else
-        Push(q, IDS.Ability.SummonVoidwalker)
+
+    -- Prefer Voidwalker as soon as it's available
+    if level >= 10 and level < 20 and Known(IDS.Ability.SummonVoidwalker) then
+      Push(q, IDS.Ability.SummonVoidwalker)
+    else
+      if spec == "Affliction" then
+        -- Felhunter for pvp/dispel utility, or imp for leveling
+        if level >= 30 and Known(IDS.Ability.SummonFelhunter) then
+          Push(q, IDS.Ability.SummonFelhunter)
+        elseif Known(IDS.Ability.SummonImp) then
+          Push(q, IDS.Ability.SummonImp)
+        end
+      elseif spec == "Destruction" then
+        -- Imp for damage boost
+        if Known(IDS.Ability.SummonImp) then
+          Push(q, IDS.Ability.SummonImp)
+        end
+      else -- Demonology
+        -- Succubus for damage, Voidwalker for tanking
+        if level >= 20 and Known(IDS.Ability.SummonSuccubus) then
+          Push(q, IDS.Ability.SummonSuccubus)
+        elseif Known(IDS.Ability.SummonVoidwalker) then
+          Push(q, IDS.Ability.SummonVoidwalker)
+        elseif Known(IDS.Ability.SummonImp) then
+          Push(q, IDS.Ability.SummonImp)
+        end
       end
     end
   end
-  
+
   return q
 end
 

--- a/classes/Engines/warrior_engine.lua
+++ b/classes/Engines/warrior_engine.lua
@@ -4,21 +4,38 @@ DEFAULT_CHAT_FRAME:AddMessage("|cff55ff55[TacoRot]|r Warrior engine loaded")
 local TR = _G.TacoRot
 local IDS = _G.TacoRot_IDS_Warrior
 
+local TOKEN = "WARRIOR"
+
+local function Pad()
+  local p = TR and TR.db and TR.db.profile and TR.db.profile.pad
+  local v = p and p[TOKEN]
+  if not v then return {enabled = true, gcd = 1.5} end
+  if v.enabled == nil then v.enabled = true end
+  v.gcd = v.gcd or 1.5
+  return v
+end
+
+local function Known(id)
+  return id and IsSpellKnown and IsSpellKnown(id)
+end
+
 -- Helper functions
 local function BuffCfg()
   return (TR.db and TR.db.profile and TR.db.profile.buff and TR.db.profile.buff.WARRIOR) or {}
 end
 
 local function ReadyNow(id)
-  if not id then return false end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
   return start == 0 or (start + dur - GetTime()) < 0.1
 end
 
 local function ReadySoon(id)
-  if not id then return false end
+  local pad = Pad()
+  if not pad.enabled then return ReadyNow(id) end
+  if not Known(id) then return false end
   local start, dur = GetSpellCooldown(id)
-  return start == 0 or (start + dur - GetTime()) < 1.5
+  return start == 0 or (start + dur - GetTime()) < (pad.gcd or 1.5)
 end
 
 local function BuffUp(unit, spellID)


### PR DESCRIPTION
## Summary
- guard readiness checks with `IsSpellKnown` in Hunter, Warrior, Mage and Rogue engines
- hook up per-class padding options
- prevents suggesting high-level buffs or pet actions already active
- recommend Voidwalker for Warlocks starting at level 10 and skip unknown pet summons

## Testing
- `busted -v` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden / repository not signed)*
- `lua tests/core_spec.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5114f08188330a7d7c6feee6b1c5f